### PR TITLE
FindBlas and Fix compilation opencv 3.4.4

### DIFF
--- a/darknet_ros/CMakeLists.txt
+++ b/darknet_ros/CMakeLists.txt
@@ -12,6 +12,9 @@ find_path(DARKNET_PATH
 message(STATUS "Darknet path dir = ${DARKNET_PATH}")
 add_definitions(-DDARKNET_FILE_PATH="${DARKNET_PATH}")
 
+# Find blas
+find_package(BLAS REQUIRED)
+
 # Find CUDA
 find_package(CUDA QUIET)
 if (CUDA_FOUND)

--- a/darknet_ros/src/YoloObjectDetector.cpp
+++ b/darknet_ros/src/YoloObjectDetector.cpp
@@ -591,27 +591,30 @@ void YoloObjectDetector::yolo()
 
 }
 
-template <typename T = cv::Mat>
-IplImage* newIplImage(T& m) {
-    // Works after CV_VERSION_STRING >= 3.4.4
-    // https://github.com/opencv/opencv/commit/ad146e5a6b931ac5d179d4fedc58cef99a3c9e7e
+#if CV_VERSION_MAJOR > 3 || \
+    (CV_VERSION_MAJOR == 3 && CV_VERSION_MINOR > 4) || \
+    (CV_VERSION_MAJOR == 3 && CV_VERSION_MINOR == 4 && CV_VERSION_REVISION >= 4)
+// Works after CV_VERSION_STRING >= 3.4.4
+// https://github.com/opencv/opencv/commit/ad146e5a6b931ac5d179d4fedc58cef99a3c9e7e
+
+IplImage* newIplImage(cv::Mat& m) {
     CV_Assert( m.dims <= 2);
     IplImage* self = new IplImage();
     *self = cvIplImage(m);
     return self;
 }
 
-template <typename T>
-IplImage* newIplImage(
-    typename std::enable_if<
-    std::is_convertible<T, IplImage>::value,
-    T>::type& m
-    )
+#else
+// Works before CV_VERSION_STRING < 3.4.4
+// https://github.com/opencv/opencv/commit/ad146e5a6b931ac5d179d4fedc58cef99a3c9e7e
+
+IplImage* newIplImage(cv::Mat& m)
 {
-    // Works before CV_VERSION_STRING < 3.4.4
-    // https://github.com/opencv/opencv/commit/ad146e5a6b931ac5d179d4fedc58cef99a3c9e7e
     return new IplImage(m);
 }
+
+#endif // CV_MAJOR_VERSION
+
 
 IplImageWithHeader_ YoloObjectDetector::getIplImageWithHeader()
 {

--- a/darknet_ros/src/YoloObjectDetector.cpp
+++ b/darknet_ros/src/YoloObjectDetector.cpp
@@ -591,9 +591,31 @@ void YoloObjectDetector::yolo()
 
 }
 
+template <typename T = cv::Mat>
+IplImage* newIplImage(T& m) {
+    // Works after CV_VERSION_STRING >= 3.4.4
+    // https://github.com/opencv/opencv/commit/ad146e5a6b931ac5d179d4fedc58cef99a3c9e7e
+    CV_Assert( m.dims <= 2);
+    IplImage* self = new IplImage();
+    *self = cvIplImage(m);
+    return self;
+}
+
+template <typename T>
+IplImage* newIplImage(
+    typename std::enable_if<
+    std::is_convertible<T, IplImage>::value,
+    T>::type& m
+    )
+{
+    // Works before CV_VERSION_STRING < 3.4.4
+    // https://github.com/opencv/opencv/commit/ad146e5a6b931ac5d179d4fedc58cef99a3c9e7e
+    return new IplImage(m);
+}
+
 IplImageWithHeader_ YoloObjectDetector::getIplImageWithHeader()
 {
-  IplImage* ROS_img = new IplImage(camImageCopy_);
+  IplImage* ROS_img = newIplImage(camImageCopy_);
   IplImageWithHeader_ header = {.image = ROS_img, .header = imageHeader_};
   return header;
 }


### PR DESCRIPTION
1. I got an error about finding blas.h. So I added FindBlas to CMakeLists.txt

2. In opencv 3.4.4, `IplImage` constructor from `cv::Mat` has been removed. Fixed that.